### PR TITLE
Server App and Storybook from server

### DIFF
--- a/.nowignore
+++ b/.nowignore
@@ -1,0 +1,4 @@
+build
+storybook-static
+/resources
+.env

--- a/client/.storybook/webpack.config.js
+++ b/client/.storybook/webpack.config.js
@@ -1,0 +1,7 @@
+module.exports = async ({ config, mode }) => {
+  if (mode === 'PRODUCTION') {
+    // Change public path to allow deployment into a subpath like https://example.com/storybook
+    config.output.publicPath = '/storybook/';
+  }
+  return config;
+};

--- a/client/package.json
+++ b/client/package.json
@@ -18,11 +18,12 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build-app": "react-scripts build",
+    "build": "npm run build-app && npm run build-storybook",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "storybook": "start-storybook -p 9009 -s public",
-    "build-storybook": "build-storybook -s public"
+    "build-storybook": "build-storybook -s public -o build/storybook"
   },
   "browserslist": {
     "production": [

--- a/now.json
+++ b/now.json
@@ -6,6 +6,17 @@
       "src": "package.json",
       "use": "@now/static-build",
       "config": { "distDir": "client/storybook-static" }
+    },
+    { "src": "server.js", "use": "@now/node-server" }
+  ],
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "/server.js"
     }
-  ]
+  ],
+  "env": {
+    "MONGO_URL": "@pension_halstrup_mongo_url",
+    "DB_NAME": "@pension_halstrup_db_name"
+  }
 }

--- a/now.json
+++ b/now.json
@@ -3,15 +3,19 @@
   "version": 2,
   "builds": [
     {
-      "src": "package.json",
+      "src": "client/package.json",
       "use": "@now/static-build",
-      "config": { "distDir": "client/storybook-static" }
+      "config": { "distDir": "build" }
     },
     { "src": "server.js", "use": "@now/node-server" }
   ],
   "routes": [
     {
       "src": "/(.*)",
+      "dest": "/client/$1"
+    },
+    {
+      "src": "/api/(.*)",
       "dest": "/server.js"
     }
   ],

--- a/package.json
+++ b/package.json
@@ -4,14 +4,13 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build-client": "cd client && npm run build",
-    "build-storybook": "cd client && npm run build-storybook",
-    "build": "npm run build-storybook && npm run build-client",
+    "build": "cd client && npm run build",
     "client": "cd client && npm start",
     "server": "node server.js",
     "storybook": "cd client && npm run storybook",
     "test": "cd client && npm test",
-    "postinstall": "cd client && npm install"
+    "postinstall": "cd client && npm install",
+    "start": "node server.js"
   },
   "repository": {
     "type": "git",

--- a/server.js
+++ b/server.js
@@ -1,5 +1,6 @@
 require('dotenv').config();
 const express = require('express');
+const path = require('path');
 const { initDb } = require('./lib/database');
 const { getImages } = require('./lib/images');
 
@@ -8,6 +9,17 @@ const app = express();
 app.get('/api/images', async (request, response) => {
   const images = await getImages();
   response.json(images);
+});
+
+// Server storybook
+app.use('/storybook', express.static(path.join(__dirname, 'client/storybook-static')));
+
+// Serve any static files
+app.use(express.static(path.join(__dirname, 'client/build')));
+
+// Handle React routing, return all requests to React app
+app.get('*', function(req, res) {
+  res.sendFile(path.join(__dirname, 'client/build', 'index.html'));
 });
 
 initDb(process.env.MONGO_URL, process.env.DB_NAME).then(() => {

--- a/server.js
+++ b/server.js
@@ -11,9 +11,6 @@ app.get('/api/images', async (request, response) => {
   response.json(images);
 });
 
-// Server storybook
-app.use('/storybook', express.static(path.join(__dirname, 'client/storybook-static')));
-
 // Serve any static files
 app.use(express.static(path.join(__dirname, 'client/build')));
 


### PR DESCRIPTION
I had to customize storybook webpack configuration to allow deployment into subpath:
https://storybook.js.org/docs/configurations/custom-webpack-config/
Storybook ist deployed on `/storybook/index.html` (https://pensionhalstrup.lmachens.now.sh/storybook/index.html).

The now secrets pension_halstrup_mongo_url and  pension_halstrup_db_name are added with `now secrets add pension_halstrup_mongo_url  "mongourl://...."` and `now secrets add pension_halstrup_db_name pensionhalstrup`:
https://zeit.co/docs/now-cli#commands/secrets

Note that I had to change some paths.
