### PR TITLE
Build storybook

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build-app": "react-scripts build",
-    "build": "npm run build-app",
+    "build": "npm run build-app && npm run build-storybook",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "storybook": "start-storybook -p 9009 -s public",


### PR DESCRIPTION
Heroku won't install devDependencies by default. Thus, `build-storybook` is not found in the build process. 
If we like to build and deploy storybook, we can change the heroku config:
`heroku config:set NPM_CONFIG_PRODUCTION=false`

Storybook is deployed in `/storybook`